### PR TITLE
Fix Vcs-Git field in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Tong Sun <suntong001@users.sourceforge.net>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.6
 Homepage: http://www.datsi.fi.upm.es/~frosal/
-Vcs-Git: git://github.com/shc-build.git
+Vcs-Git: https://github.com/suntong001/shc-build.git
 Vcs-Browser: https://github.com/suntong001/shc-build
 
 Package: shc


### PR DESCRIPTION
The old URI was non-existent,
and Debian now recommends the use of secure HTTPS URIs too.

----

Hi Tong SUN,

Here is a bit more information:

On your Debian [Packages overview for Tong Sun](https://qa.debian.org/developer.php?login=suntong001@users.sourceforge.net), the VCS column for the shc package is showing an [ERROR](https://qa.debian.org/cgi-bin/vcswatch?package=shc), and clicking into it reveals:

> Error: **Cloning into bare repository '/srv/scratch/qa.debian.org/vcswatch/s/shc'... fatal: remote error: Repository not found.**

This pull request fixes that error.

Cheers,
Anthony
